### PR TITLE
Add uploadFiles method

### DIFF
--- a/src/DatasetManager.type.js
+++ b/src/DatasetManager.type.js
@@ -82,4 +82,7 @@ interface DatasetManager {
 
   // We assume we can write to the dataset if not specified
   isWritable?: () => boolean;
+  
+  // If this is undefined, it's assumed the dataset manager doesn't support uploading
+  uploadFiles?: (files: Array<{ data: Buffer, destinationUrl: string }>) => Promise<{ uploadUrl: string }>
 }


### PR DESCRIPTION
As discussed with @Ownmarc! Should we also handle deletions? Other browsing functionality? This kind of functionality should could also be handled outside the DatasetManagers, since using a CollaborativeDatasetManager doesn't imply your data is hosted in any particular location. (e.g. we might be mixing storage with Dataset management?)

I think it's probably fine to support this in a DatasetManager as long as it's optional. My guess is CollaborativeSession users will use Minio or AWS for storage- but it'll just be handled outside the dataset manager (which is fine)